### PR TITLE
Fixed missing player status

### DIFF
--- a/player.go
+++ b/player.go
@@ -134,13 +134,13 @@ func (p *Player) GetStatus() (string, error) {
 	//Codes documented here http://www.fluidsynth.org/api/midi_8h.html#a5ec93766f61465dedbbac9bdb76ced83
 
 	switch status {
-	case 0:
+	case C.FLUID_PLAYER_READY:
 		return FLUID_PLAYER_READY, nil
-	case 1:
+	case C.FLUID_PLAYER_PLAYING:
 		return FLUID_PLAYER_PLAYING, nil
-	case 2:
+	case C.FLUID_PLAYER_STOPPING:
 		return FLUID_PLAYER_STOPPING, nil
-	case 3:
+	case C.FLUID_PLAYER_DONE:
 		return FLUID_PLAYER_DONE, nil
 	default:
 		return "UNKNOWN", fmt.Errorf("unknown status code: %d", status)

--- a/player.go
+++ b/player.go
@@ -14,6 +14,13 @@ type Player struct {
 	open bool
 }
 
+const (
+	FLUID_PLAYER_READY    = "READY"
+	FLUID_PLAYER_PLAYING  = "PLAYING"
+	FLUID_PLAYER_STOPPING = "STOPPING"
+	FLUID_PLAYER_DONE     = "DONE"
+)
+
 func NewPlayer(synth Synth) Player {
 	return Player{
 		ptr:  C.new_fluid_player(synth.ptr),
@@ -128,11 +135,13 @@ func (p *Player) GetStatus() (string, error) {
 
 	switch status {
 	case 0:
-		return "READY", nil
+		return FLUID_PLAYER_READY, nil
 	case 1:
-		return "PLAYING", nil
+		return FLUID_PLAYER_PLAYING, nil
 	case 2:
-		return "DONE", nil
+		return FLUID_PLAYER_STOPPING, nil
+	case 3:
+		return FLUID_PLAYER_DONE, nil
 	default:
 		return "UNKNOWN", fmt.Errorf("unknown status code: %d", status)
 	}


### PR DESCRIPTION
- Fixed an issue where the `DONE` status of the player was not recognized as a valid status.
- Made all player status strings available as constants.

Fluidsynth reference: https://github.com/FluidSynth/fluidsynth/blob/master/include/fluidsynth/midi.h#L244-L250